### PR TITLE
Technical Cleanup

### DIFF
--- a/DueTimer.cpp
+++ b/DueTimer.cpp
@@ -23,6 +23,7 @@ const DueTimer::Timer DueTimer::Timers[9] = {
 };
 
 void (*DueTimer::callbacks[9])() = {};
+double DueTimer::_frequency[9] = {-1,-1,-1,-1,-1,-1,-1,-1,-1};
 
 /*
 	Initializing all timers, so you can use them like this: Timer0.start();
@@ -45,8 +46,6 @@ DueTimer::DueTimer(int _timer){
 	*/
 
 	timer = _timer;
-
-	_frequency[timer] = -1;
 }
 
 DueTimer DueTimer::getAvailable(){


### PR DESCRIPTION
- Setting up the frequency (and thus enabling all timers)
  whenever the library is used is selfish:
  Maybe someone else wants to use one or more of the
  Timers/Counters in his code for other purposes.
- We don't use the register RA and its triggered output line
  TIOA in any way, so we don't need to care to set it up.
