### PR TITLE
Using the Timer Counter Block of the Arduino Due as a hardware counter

### DIFF
--- a/DueTimer.cpp
+++ b/DueTimer.cpp
@@ -11,15 +11,15 @@
 #include "DueTimer.h"
 
 const DueTimer::Timer DueTimer::Timers[9] = {
-	{TC0, 0, TC0_IRQn,   22},
-	{TC0, 1, TC1_IRQn,   59}, // A5
-	{TC0, 2, TC2_IRQn,   31},
-	{TC1, 0, TC3_IRQn,   57}, // A3
-	{TC1, 1, TC4_IRQn,   56}, // A2
-	{TC1, 2, TC5_IRQn,   67},
-	{TC2, 0, TC6_IRQn, NULL}, // n/a
-	{TC2, 1, TC7_IRQn, NULL}, // LED "RX"
-	{TC2, 2, TC8_IRQn,   30},
+	{TC0, 0, TC0_IRQn,   22, PIO_PERIPH_B},
+	{TC0, 1, TC1_IRQn,   59, PIO_PERIPH_A}, // A5
+	{TC0, 2, TC2_IRQn,   31, PIO_PERIPH_A},
+	{TC1, 0, TC3_IRQn,   57, PIO_PERIPH_B}, // A3
+	{TC1, 1, TC4_IRQn,   56, PIO_PERIPH_B}, // A2
+	{TC1, 2, TC5_IRQn,   67, PIO_PERIPH_A},
+	{TC2, 0, TC6_IRQn, NULL, PIO_PERIPH_B}, // n/a
+	{TC2, 1, TC7_IRQn, NULL, PIO_PERIPH_B}, // LED "RX"
+	{TC2, 2, TC8_IRQn,   30, PIO_PERIPH_B},
 };
 
 void (*DueTimer::callbacks[9])() = {};
@@ -158,10 +158,13 @@ bool DueTimer::setUpCounter() {
 
 	Timer t = Timers[timer];
 
-	if (t.tclk == NULL) return false;
+	if (t.tclk_pin == NULL) return false;
 
 	// Set up the external clock input 
-	pinMode(t.tclk, INPUT);
+	PIO_Configure(g_APinDescription[t.tclk_pin].pPort,
+		t.tclk_periph,
+		g_APinDescription[t.tclk_pin].ulPin,
+		PIO_DEFAULT);
 
 	// Tell the Power Management Controller to disable 
 	// the write protection of the (Timer/Counter) registers:

--- a/DueTimer.h
+++ b/DueTimer.h
@@ -36,7 +36,8 @@ public:
 		Tc *tc;
 		uint32_t channel;
 		IRQn_Type irq;
-		int tclk;
+		int tclk_pin;
+		EPioType tclk_periph;
 	};
 
 	static DueTimer getAvailable();


### PR DESCRIPTION
 Adding support to use the _Timer Counter Block_ of the Arduino Due as a hardware counter with the TCLKx pins as clock input for the counters.

This pull request is not finished in the way that you should pull it right away, I just created it to move our discussion from the [specific commit](https://github.com/pklaus/DueTimer/commit/b6034b5#commitcomment-3383519) to this pull request because the commit&comment might get lost as I'll continuously rebase the branch on the current upstream master (thus auto-creating new commits). So @ivanseidel, please post your comment here again.
