### PR TITLE
start() and stop() fix

### DIFF
--- a/DueTimer.cpp
+++ b/DueTimer.cpp
@@ -97,6 +97,8 @@ DueTimer DueTimer::start(long microseconds){
 
 	NVIC_ClearPendingIRQ(Timers[timer].irq);
 	NVIC_EnableIRQ(Timers[timer].irq);
+	
+	TC_Start(Timers[timer].tc, Timers[timer].channel);
 
 	return *this;
 }
@@ -107,6 +109,8 @@ DueTimer DueTimer::stop(){
 	*/
 
 	NVIC_DisableIRQ(Timers[timer].irq);
+	
+	TC_Stop(Timers[timer].tc, Timers[timer].channel);
 
 	return *this;
 }
@@ -184,8 +188,6 @@ DueTimer DueTimer::setFrequency(double frequency){
 	TC_Configure(t.tc, t.channel, TC_CMR_WAVE | TC_CMR_WAVSEL_UP_RC | clock);
 	// Reset counter and fire interrupt when RC value is matched:
 	TC_SetRC(t.tc, t.channel, rc);
-	// Start the Counter channel
-	TC_Start(t.tc, t.channel);
 	// Enable the RC Compare Interrupt...
 	t.tc->TC_CHANNEL[t.channel].TC_IER=TC_IER_CPCS;
 	// ... and disable all others.


### PR DESCRIPTION
Presently, start() and stop() simply enable and disable timer IRQ, but
do not actually start or stop the timer. Further, setFrequency() is,
somewhat counterintuitively, responsible for starting the timer.

The impact of this is that one may set the frequency for, say, 1Hz. At
an arbitrary time later, one might issue the start() command. This will
cause the first interrupt to occur at an arbitrary time after the
start() command has been issued. For example, if start is issued 0.3s
after setFrequency(), the first period will be 0.7s after start() is
issued.

This same behavior occurs when stop() is issued, then start() at an
arbitrary time later.

In order to fix this, I've introduced 3 changes:
1. setFrequency() no longer starts the timer
2. start() now uses TC_Start to properly reset the counter value to 0,
   then start the timer
3. stop() now uses TC_Stop to properly stop the counter when not in use
