### PR TITLE
Update DueTimer.cpp

### DIFF
--- a/DueTimer.cpp
+++ b/DueTimer.cpp
@@ -155,7 +155,7 @@ uint8_t DueTimer::bestClock(double frequency, uint32_t& retRC){
 	float error;
 	int clkId = 3;
 	int bestClock = 3;
-	float bestError = 1.0;
+	float bestError = 9.999e99;
 	do
 	{
 		ticks = (float) VARIANT_MCK / frequency / (float) clockConfig[clkId].divisor;


### PR DESCRIPTION
bestError in bestClock() needs to start from a higher value to account for scaling by clockConfig[clkId].divisor

This bug manifests when trying to set the frequency to exactly 32000. The problem isn't there when setting the frequency to 31999 or 32001.