### PR TITLE
added compatibility with SAM3A4C (used by OpenTracker)

### DIFF
--- a/DueTimer.cpp
+++ b/DueTimer.cpp
@@ -43,12 +43,12 @@ const DueTimer::Timer DueTimer::Timers[NUM_TIMERS] = {
 #else
 	void (*DueTimer::callbacks[NUM_TIMERS])() = {};
 #endif
-double DueTimer::_frequency[NUM_TIMERS] = {
-  -1,-1,-1,-1,-1,-1,
+		
 #if NUM_TIMERS > 6
-  -1,-1,-1
+double DueTimer::_frequency[NUM_TIMERS] = {-1,-1,-1,-1,-1,-1,-1,-1,-1};
+#else
+double DueTimer::_frequency[NUM_TIMERS] = {-1,-1,-1,-1,-1,-1};
 #endif
-  };
 
 /*
 	Initializing all timers, so you can use them like this: Timer0.start();

--- a/DueTimer.h
+++ b/DueTimer.h
@@ -7,12 +7,12 @@
   Released into the public domain.
 */
 
-#ifdef __arm__
+#include "Arduino.h"
+
+#if defined(_SAM3XA_)
 
 #ifndef DueTimer_h
 #define DueTimer_h
-
-#include "Arduino.h"
 
 #include <inttypes.h>
 

--- a/DueTimer.h
+++ b/DueTimer.h
@@ -31,7 +31,11 @@
 #endif
 
 
+#if defined TC2
 #define NUM_TIMERS  9
+#else
+#define NUM_TIMERS  6
+#endif
 
 class DueTimer
 {
@@ -54,9 +58,11 @@ protected:
   friend void TC3_Handler(void);
   friend void TC4_Handler(void);
   friend void TC5_Handler(void);
+#if NUM_TIMERS > 6
   friend void TC6_Handler(void);
   friend void TC7_Handler(void);
   friend void TC8_Handler(void);
+#endif
 
 	static void (*callbacks[NUM_TIMERS])();
 
@@ -98,9 +104,11 @@ extern DueTimer Timer1;
 	extern DueTimer Timer4;
 	extern DueTimer Timer5;
 #endif
+#if NUM_TIMERS > 6
 extern DueTimer Timer6;
 extern DueTimer Timer7;
 extern DueTimer Timer8;
+#endif
 
 #endif
 

--- a/library.json
+++ b/library.json
@@ -16,7 +16,7 @@
         "type": "git",
         "url": "https://github.com/ivanseidel/DueTimer.git"
     },
-    "version": "1.4.7",
+    "version": "1.4.8",
     "license": "MIT",
     "frameworks": "arduino",
     "platforms": "atmelsam",

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=DueTimer
-version=1.4.7
+version=1.4.8
 author=Ivan Seidel <ivanseidel@gmail.com>
 maintainer=Ivan Seidel <ivanseidel@gmail.com>
 sentence=Timer Library fully implemented for Arduino DUE
-paragraph=There are 9 Timer objects already instantiated for you: Timer0, Timer1, Timer2, Timer3, Timer4, Timer5, Timer6, Timer7 and Timer8.
+paragraph=There are 6 or 9 Timer objects already instantiated for you: Timer0, Timer1, Timer2, Timer3, Timer4, Timer5 and Timer6, Timer7, Timer8 where supported by the hardware.
 category=Timing
 url=https://github.com/ivanseidel/DueTimer
 architectures=sam


### PR DESCRIPTION
This patch fixes compatibility with 100-pin variant of SAM3A/X family, that does not have Timer2. For example, SAM3A4C is used by OpenTracker development kit.
It now uses SystemCoreClock instead of VARIANT_MCK for clock calculations, so that if you keep the global variable up-to-date with SystemCoreClockUpdate() after CPU clock changes (low power modes) you can restart timers and obtain the correct interrupt rate. Otherwise it would be difficult to adjust timer period after dynamic clock changes.
