### PR TITLE
Changed period datatype for more accuracy

### DIFF
--- a/DueTimer.cpp
+++ b/DueTimer.cpp
@@ -102,7 +102,7 @@ DueTimer& DueTimer::detachInterrupt(void){
 	return *this;
 }
 
-DueTimer& DueTimer::start(long microseconds){
+DueTimer& DueTimer::start(double microseconds){
 	/*
 		Start the timer
 		If a period is set, then sets the period and start the timer
@@ -231,7 +231,7 @@ DueTimer& DueTimer::setFrequency(double frequency){
 	return *this;
 }
 
-DueTimer& DueTimer::setPeriod(unsigned long microseconds){
+DueTimer& DueTimer::setPeriod(double microseconds){
 	/*
 		Set the period of the timer (in microseconds)
 	*/
@@ -250,7 +250,7 @@ double DueTimer::getFrequency(void) const {
 	return _frequency[timer];
 }
 
-long DueTimer::getPeriod(void) const {
+double DueTimer::getPeriod(void) const {
 	/*
 		Get current time period
 	*/

--- a/DueTimer.h
+++ b/DueTimer.h
@@ -77,13 +77,13 @@ public:
 	DueTimer(unsigned short _timer);
 	DueTimer& attachInterrupt(void (*isr)());
 	DueTimer& detachInterrupt(void);
-	DueTimer& start(long microseconds = -1);
+	DueTimer& start(double microseconds = -1);
 	DueTimer& stop(void);
 	DueTimer& setFrequency(double frequency);
-	DueTimer& setPeriod(unsigned long microseconds);
+	DueTimer& setPeriod(double microseconds);
 
 	double getFrequency(void) const;
-	long getPeriod(void) const;
+	double getPeriod(void) const;
 };
 
 // Just to call Timer.getAvailable instead of Timer::getAvailable() :


### PR DESCRIPTION
Increasing accuracy by modifying microseconds datatype to double. This modification helped me on my project by beeing able to get precision lesser than 0.1 Hz. Also, might help to solve this issue #55.